### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/ctdb/tests/takeover/simulation/ctdb_takeover.py
+++ b/ctdb/tests/takeover/simulation/ctdb_takeover.py
@@ -244,7 +244,7 @@ class Node(object):
         return ip in self.public_addresses
 
     def node_ip_coverage(self, ips=None):
-        return len([a for a in self.current_addresses if ips == None or a in ips])
+        return len([a for a in self.current_addresses if ips is None or a in ips])
 
     def set_imbalance(self, imbalance=-1):
         """Set the imbalance metric to the given value.  If none given

--- a/python/samba/netcmd/delegation.py
+++ b/python/samba/netcmd/delegation.py
@@ -56,7 +56,7 @@ class cmd_delegation_show(Command):
         creds = credopts.get_credentials(lp)
         paths = provision.provision_paths_from_lp(lp, lp.get("realm"))
 
-        if H == None:
+        if H is None:
             path = paths.samdb
         else:
             path = H
@@ -121,7 +121,7 @@ class cmd_delegation_for_any_service(Command):
         lp = sambaopts.get_loadparm()
         creds = credopts.get_credentials(lp)
         paths = provision.provision_paths_from_lp(lp, lp.get("realm"))
-        if H == None:
+        if H is None:
             path = paths.samdb
         else:
             path = H
@@ -175,7 +175,7 @@ class cmd_delegation_for_any_protocol(Command):
         lp = sambaopts.get_loadparm()
         creds = credopts.get_credentials(lp, fallback_machine=True)
         paths = provision.provision_paths_from_lp(lp, lp.get("realm"))
-        if H == None:
+        if H is None:
             path = paths.samdb
         else:
             path = H
@@ -220,7 +220,7 @@ class cmd_delegation_add_service(Command):
         lp = sambaopts.get_loadparm()
         creds = credopts.get_credentials(lp)
         paths = provision.provision_paths_from_lp(lp, lp.get("realm"))
-        if H == None:
+        if H is None:
             path = paths.samdb
         else:
             path = H
@@ -274,7 +274,7 @@ class cmd_delegation_del_service(Command):
         lp = sambaopts.get_loadparm()
         creds = credopts.get_credentials(lp)
         paths = provision.provision_paths_from_lp(lp, lp.get("realm"))
-        if H == None:
+        if H is None:
             path = paths.samdb
         else:
             path = H

--- a/source3/stf/spoolss.py
+++ b/source3/stf/spoolss.py
@@ -9,7 +9,7 @@ class PrintServerTest(comfychair.TestCase):
     def setUp(self):
         # TODO: create a test printer
         self.server = stf.get_server(platform = "nt")
-        self.require(self.server != None, "print server required")
+        self.require(self.server is not None, "print server required")
         # TODO: remove hardcoded printer name
         self.printername = "p"
         self.uncname = "\\\\%s\\%s" % \
@@ -20,7 +20,7 @@ class W2kPrintServerTest(comfychair.TestCase):
     def setUp(self):
         # TODO: create a test printer
         self.server = stf.get_server(platform = "nt5")
-        self.require(self.server != None, "print server required")
+        self.require(self.server is not None, "print server required")
         # TODO: remove hardcoded printer name
         self.printername = "p"
         self.uncname = "\\\\%s\\%s" % \

--- a/source4/dsdb/tests/python/dirsync.py
+++ b/source4/dsdb/tests/python/dirsync.py
@@ -226,19 +226,19 @@ class SimpleDirsyncTests(DirsyncBaseTests):
                                     expression="samaccountname=*",
                                     controls=["dirsync:1:0:1"])
         # Check that nTSecurityDescriptor is returned as it's the case when doing dirsync
-        self.assertTrue(res.msgs[0].get("ntsecuritydescriptor") != None)
+        self.assertTrue(res.msgs[0].get("ntsecuritydescriptor") is not None)
         # Check that non replicated attributes are not returned
-        self.assertTrue(res.msgs[0].get("badPwdCount") == None)
+        self.assertTrue(res.msgs[0].get("badPwdCount") is None)
         # Check that non forward link are not returned
-        self.assertTrue(res.msgs[0].get("memberof") == None)
+        self.assertTrue(res.msgs[0].get("memberof") is None)
 
         # Asking for instanceType will return also objectGUID
         res = self.ldb_admin.search(self.base_dn,
                                     expression="samaccountname=Administrator",
                                     attrs=["instanceType"],
                                     controls=["dirsync:1:0:1"])
-        self.assertTrue(res.msgs[0].get("objectGUID") != None)
-        self.assertTrue(res.msgs[0].get("instanceType") != None)
+        self.assertTrue(res.msgs[0].get("objectGUID") is not None)
+        self.assertTrue(res.msgs[0].get("instanceType") is not None)
 
         # We don't return an entry if asked for objectGUID
         res = self.ldb_admin.search(self.base_dn,
@@ -252,10 +252,10 @@ class SimpleDirsyncTests(DirsyncBaseTests):
                                     expression="(distinguishedName=%s)" % str(self.base_dn),
                                     attrs=["name"],
                                     controls=["dirsync:1:0:1"])
-        self.assertTrue(res.msgs[0].get("objectGUID") != None)
-        self.assertTrue(res.msgs[0].get("name") != None)
-        self.assertTrue(res.msgs[0].get("parentGUID") == None)
-        self.assertTrue(res.msgs[0].get("instanceType") != None)
+        self.assertTrue(res.msgs[0].get("objectGUID") is not None)
+        self.assertTrue(res.msgs[0].get("name") is not None)
+        self.assertTrue(res.msgs[0].get("parentGUID") is None)
+        self.assertTrue(res.msgs[0].get("instanceType") is not None)
 
          # Asking for name will return also objectGUID and parentGUID
         # and instanceType and of course name
@@ -263,10 +263,10 @@ class SimpleDirsyncTests(DirsyncBaseTests):
                                     expression="samaccountname=Administrator",
                                     attrs=["name"],
                                     controls=["dirsync:1:0:1"])
-        self.assertTrue(res.msgs[0].get("objectGUID") != None)
-        self.assertTrue(res.msgs[0].get("name") != None)
-        self.assertTrue(res.msgs[0].get("parentGUID") != None)
-        self.assertTrue(res.msgs[0].get("instanceType") != None)
+        self.assertTrue(res.msgs[0].get("objectGUID") is not None)
+        self.assertTrue(res.msgs[0].get("name") is not None)
+        self.assertTrue(res.msgs[0].get("parentGUID") is not None)
+        self.assertTrue(res.msgs[0].get("instanceType") is not None)
 
         # Asking for dn will not return not only DN but more like if attrs=*
         # parentGUID should be returned
@@ -363,7 +363,7 @@ class SimpleDirsyncTests(DirsyncBaseTests):
                                     controls=["dirsync:1:0:0"])
         self.assertEqual(len(res.msgs), nb - 1)
         if nb > 1:
-            self.assertTrue(res.msgs[0].get("objectGUID") != None)
+            self.assertTrue(res.msgs[0].get("objectGUID") is not None)
         else:
             res = self.ldb_admin.search(self.base_dn,
                                         expression="(objectclass=configuration)",
@@ -452,8 +452,8 @@ class SimpleDirsyncTests(DirsyncBaseTests):
                                     expression="(&(objectClass=organizationalUnit)(!(isDeleted=*)))",
                                     controls=[control3])
 
-        self.assertTrue(res[0].get("parentGUID") != None)
-        self.assertTrue(res[0].get("name") != None)
+        self.assertTrue(res[0].get("parentGUID") is not None)
+        self.assertTrue(res[0].get("name") is not None)
         delete_force(self.ldb_admin, ouname)
 
     def test_dirsync_linkedattributes(self):
@@ -571,7 +571,7 @@ class SimpleDirsyncTests(DirsyncBaseTests):
         guid2 = str(ndr_unpack(misc.GUID,res[0].get("objectGUID")[0]))
         self.assertEqual(guid2, guid)
         self.assertTrue(res[0].get("isDeleted"))
-        self.assertTrue(res[0].get("name") != None)
+        self.assertTrue(res[0].get("name") is not None)
 
     def test_cookie_from_others(self):
         res = self.ldb_admin.search(self.base_dn,
@@ -596,7 +596,7 @@ class ExtendedDirsyncTests(SimpleDirsyncTests):
                                     expression="(name=Administrators)",
                                     controls=["dirsync:1:%d:1" % flag_incr_linked])
 
-        self.assertTrue(res[0].get("member;range=1-1") != None )
+        self.assertTrue(res[0].get("member;range=1-1") is not None )
         self.assertTrue(len(res[0].get("member;range=1-1")) > 0)
         size = len(res[0].get("member;range=1-1"))
 
@@ -674,7 +674,7 @@ class ExtendedDirsyncTests(SimpleDirsyncTests):
             if str(e["name"]) == "testou3":
                 guid = str(ndr_unpack(misc.GUID,e.get("objectGUID")[0]))
 
-        self.assertTrue(guid != None)
+        self.assertTrue(guid is not None)
         ctl = str(res.controls[0]).split(":")
         ctl[1] = "1"
         ctl[2] = "1"

--- a/source4/heimdal/lib/wind/gen-normalize.py
+++ b/source4/heimdal/lib/wind/gen-normalize.py
@@ -156,7 +156,7 @@ def add(table, k, v):
         table[0] = v[0]
     else:
         i = int(k[0], 0x10) + 1
-        if table[i] == None:
+        if table[i] is None:
             table[i] = createTable()
         add(tables[table[i]], k[1:], v)
 
@@ -175,10 +175,10 @@ for k in sortedKeys(tables) :
     tableToNext[k] = len(next_table)
     l = t[1:]
     start = 0
-    while start < 16 and l[start] == None:
+    while start < 16 and l[start] is None:
         start += 1
     end = 16
-    while end > start and l[end - 1] == None:
+    while end > start and l[end - 1] is None:
         end -= 1
     tableStart[k] = start
     tableEnd[k]   = end

--- a/source4/scripting/bin/gen_hresult.py
+++ b/source4/scripting/bin/gen_hresult.py
@@ -64,7 +64,7 @@ def parseErrorDescriptions( input_file, isWinError ):
                 print "Error parsing file as line %d"%count
                 sys.exit()
             err = Errors[-1]
-            if err.err_define == None:
+            if err.err_define is None:
                 err.err_define = "HRES_" + content[0]
             else:
                 if len(content) > 0:

--- a/source4/scripting/bin/gen_ntstatus.py
+++ b/source4/scripting/bin/gen_ntstatus.py
@@ -62,7 +62,7 @@ def transformErrorName( error_name ):
 def parseErrorDescriptions( file_contents, isWinError ):
     count = 0
     for line in file_contents:
-        if line == None or line == '\t' or line == "" or line == '\n':
+        if line is None or line == '\t' or line == "" or line == '\n':
             continue
         content = line.strip().split(None,1)
         # start new error definition ?
@@ -80,7 +80,7 @@ def parseErrorDescriptions( file_contents, isWinError ):
                 print "Error parsing file as line %d"%count
                 sys.exit()
             err = Errors[-1]
-            if err.err_define == None:
+            if err.err_define is None:
                 err.err_define = transformErrorName(content[0])
             else:
                 if len(content) > 0:
@@ -122,7 +122,7 @@ def parseHeaderFile(file_contents):
                 # "#define SOMETHING NT_STATUS( num1 | num2 )" etc...
                 err_code_string = contents[2].split('(')[1].split(')')[0]
                 err_code = parseErrCodeString( err_code_string ) 
-                if  err_code != None:
+                if  err_code is not None:
                     const_define = contents[1]
 #                    print "%s 0x%x"%(const_define, err_code)
                     DefineToErrCode[const_define] = err_code

--- a/source4/scripting/devel/demodirsync.py
+++ b/source4/scripting/devel/demodirsync.py
@@ -93,7 +93,7 @@ cont = 0
 if (len(ctrls)):
     for ctl in ctrls:
         cookie = printdirsync(ctl)
-    if cookie != None:
+    if cookie is not None:
         cont = (ctl.split(':'))[1]
     print "Returned %d entries" % len(msgs)
 
@@ -109,7 +109,7 @@ while (cont == "1"):
     if (len(ctrls)):
         for ctl in ctrls:
             cookie = printdirsync(ctl)
-        if cookie != None:
+        if cookie is not None:
             cont = (ctl.split(':'))[1]
         print "Returned %d entries" % len(msgs)
 

--- a/source4/scripting/devel/repl_cleartext_pwd.py
+++ b/source4/scripting/devel/repl_cleartext_pwd.py
@@ -236,7 +236,7 @@ if __name__ == "__main__":
 
     while True:
         (level, ctr) = drs_conn.DsGetNCChanges(drs_handle, 8, req8)
-        if ctr.first_object == None and ctr.object_count != 0:
+        if ctr.first_object is None and ctr.object_count != 0:
             raise RuntimeError("DsGetNCChanges: NULL first_object with object_count=%u" % (ctr.object_count))
 
         obj_item = ctr.first_object

--- a/third_party/dnspython/dns/rdataclass.py
+++ b/third_party/dnspython/dns/rdataclass.py
@@ -81,7 +81,7 @@ def from_text(text):
     value = _by_text.get(text.upper())
     if value is None:
         match = _unknown_class_pattern.match(text)
-        if match == None:
+        if match is None:
             raise UnknownRdataclass
         value = int(match.group(1))
         if value < 0 or value > 65535:

--- a/third_party/dnspython/dns/rdatatype.py
+++ b/third_party/dnspython/dns/rdatatype.py
@@ -190,7 +190,7 @@ def from_text(text):
     value = _by_text.get(text.upper())
     if value is None:
         match = _unknown_type_pattern.match(text)
-        if match == None:
+        if match is None:
             raise UnknownRdatatype
         value = int(match.group(1))
         if value < 0 or value > 65535:

--- a/third_party/dnspython/examples/zonediff.py
+++ b/third_party/dnspython/examples/zonediff.py
@@ -219,24 +219,24 @@ The differences shown will be logical differences, not textual differences.
     if opts.use_bzr:
         old = _open(["bzr", "cat", "-r" + oldr, filename],
                     "Unable to retrieve revision %s of %s" % (oldr, filename))
-        if newr != None:
+        if newr is not None:
             new = _open(["bzr", "cat", "-r" + newr, filename],
                         "Unable to retrieve revision %s of %s" % (newr, filename))
     elif opts.use_git:
         old = _open(["git", "show", oldn],
                     "Unable to retrieve revision %s of %s" % (oldr, filename))
-        if newr != None:
+        if newr is not None:
             new = _open(["git", "show", newn],
                         "Unable to retrieve revision %s of %s" % (newr, filename))
     elif opts.use_rcs:
         old = _open(["co", "-q", "-p", "-r" + oldr, filename],
                     "Unable to retrieve revision %s of %s" % (oldr, filename))
-        if newr != None:
+        if newr is not None:
             new = _open(["co", "-q", "-p", "-r" + newr, filename],
                         "Unable to retrieve revision %s of %s" % (newr, filename))
     if not opts.use_vc:
         old = _open(oldn, "Unable to open %s" % oldn)
-    if not opts.use_vc or newr == None:
+    if not opts.use_vc or newr is None:
         new = _open(newn, "Unable to open %s" % newn)
 
     if not old or not new:

--- a/third_party/dnspython/tests/zone.py
+++ b/third_party/dnspython/tests/zone.py
@@ -208,7 +208,7 @@ class ZoneTestCase(unittest.TestCase):
     def testGetRdataset2(self):
         z = dns.zone.from_text(example_text, 'example.', relativize=True)
         rds = z.get_rdataset('@', 'loc')
-        self.failUnless(rds == None)
+        self.failUnless(rds is None)
 
     def testGetRRset1(self):
         z = dns.zone.from_text(example_text, 'example.', relativize=True)
@@ -219,7 +219,7 @@ class ZoneTestCase(unittest.TestCase):
     def testGetRRset2(self):
         z = dns.zone.from_text(example_text, 'example.', relativize=True)
         rrs = z.get_rrset('@', 'loc')
-        self.failUnless(rrs == None)
+        self.failUnless(rrs is None)
 
     def testReplaceRdataset1(self):
         z = dns.zone.from_text(example_text, 'example.', relativize=True)
@@ -272,21 +272,21 @@ class ZoneTestCase(unittest.TestCase):
         z = dns.zone.from_text(example_text, 'example.', relativize=True)
         node = z['@']
         rds = node.get_rdataset(dns.rdataclass.IN, dns.rdatatype.LOC)
-        self.failUnless(rds == None)
+        self.failUnless(rds is None)
 
     def testNodeDeleteRdataset1(self):
         z = dns.zone.from_text(example_text, 'example.', relativize=True)
         node = z['@']
         rds = node.delete_rdataset(dns.rdataclass.IN, dns.rdatatype.SOA)
         rds = node.get_rdataset(dns.rdataclass.IN, dns.rdatatype.SOA)
-        self.failUnless(rds == None)
+        self.failUnless(rds is None)
 
     def testNodeDeleteRdataset2(self):
         z = dns.zone.from_text(example_text, 'example.', relativize=True)
         node = z['@']
         rds = node.delete_rdataset(dns.rdataclass.IN, dns.rdatatype.LOC)
         rds = node.get_rdataset(dns.rdataclass.IN, dns.rdatatype.LOC)
-        self.failUnless(rds == None)
+        self.failUnless(rds is None)
 
     def testIterateRdatasets(self):
         z = dns.zone.from_text(example_text, 'example.', relativize=True)

--- a/third_party/pep8/testsuite/E71.py
+++ b/third_party/pep8/testsuite/E71.py
@@ -1,14 +1,14 @@
 #: E711
-if res == None:
+if res is None:
     pass
 #: E711
-if res != None:
+if res is not None:
     pass
 #: E711
-if None == res:
+if None is res:
     pass
 #: E711
-if None != res:
+if None is not res:
     pass
 
 #

--- a/third_party/pep8/testsuite/noqa.py
+++ b/third_party/pep8/testsuite/noqa.py
@@ -10,6 +10,6 @@ from functools import (partial, reduce, wraps,
     cmp_to_key)   # noqa
 
 a = 1
-if a == None:   # noqa
+if a is None:   # noqa
     pass
 #:

--- a/third_party/waf/wafadmin/Runner.py
+++ b/third_party/waf/wafadmin/Runner.py
@@ -143,7 +143,7 @@ class Parallel(object):
 				self.frozen = []
 			elif not self.count:
 				(jobs, tmp) = self.manager.get_next_set()
-				if jobs != None: self.maxjobs = jobs
+				if jobs is not None: self.maxjobs = jobs
 				if tmp: self.outstanding += tmp
 				break
 

--- a/third_party/waf/wafadmin/Tools/libtool.py
+++ b/third_party/waf/wafadmin/Tools/libtool.py
@@ -170,7 +170,7 @@ class libtool_la_file:
 		libs = []
 		if self.dependency_libs:
 			libs = str(self.dependency_libs).strip().split()
-		if libs == None:
+		if libs is None:
 			libs = []
 		# add la lib and libdir
 		libs.insert(0, "-l%s" % self.linkname.strip())

--- a/third_party/waf/wafadmin/Tools/msvc.py
+++ b/third_party/waf/wafadmin/Tools/msvc.py
@@ -371,12 +371,12 @@ def libname_msvc(self, libname, is_static=False, mandatory=False):
 
 	(lt_path, lt_libname, lt_static) = self.find_lt_names_msvc(lib, is_static)
 
-	if lt_path != None and lt_libname != None:
+	if lt_path is not None and lt_libname is not None:
 		if lt_static == True:
 			# file existance check has been made by find_lt_names
 			return os.path.join(lt_path,lt_libname)
 
-	if lt_path != None:
+	if lt_path is not None:
 		_libpaths=[lt_path] + self.env['LIBPATH']
 	else:
 		_libpaths=self.env['LIBPATH']

--- a/wintest/wintest.py
+++ b/wintest/wintest.py
@@ -516,7 +516,7 @@ options {
             i = child.exitstatus
             if wait_for_fail:
                 #wait for timeout or fail
-                if i == None or i > 0:
+                if i is None or i > 0:
                     return
             else:
                 if i == 0:


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:samba?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:runt18:samba?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
